### PR TITLE
Gérer les attributs provenant d'autre tables

### DIFF
--- a/src/lib/metabase.ts
+++ b/src/lib/metabase.ts
@@ -257,7 +257,8 @@ export class MetabaseClient {
             if (key === 'email') {
               acc.email = contact.email.toLowerCase();
             } else {
-              acc[key.toUpperCase().replaceAll(' ', '_')] = contact[key];
+              const formattedKey = key.toUpperCase().replace(/^.*→\s/, '').replaceAll(' ', '_');
+              acc[formattedKey] = contact[key];
             }
             return acc;
           }, {} as Partial<MetabaseContact>);


### PR DESCRIPTION
Lorsqu'une vue Metabase contient des attributs provenant d'une autre table, le `display_name` respecte le format suivant : `table - foreign_key → column_name`.

Je propose cette MR pour supprimer tout ce qui précède le charactère spécial `→`